### PR TITLE
Call WriteHeader only after proxying through response headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,13 +84,13 @@ func handleReverseRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// copy the reponse from server to the connected client request
-	w.WriteHeader(resp.StatusCode)
 	for h, v := range resp.Header {
 		for _, v := range v {
 			w.Header().Add(h, v)
 		}
 	}
+	// copy the reponse from server to the connected client request
+	w.WriteHeader(resp.StatusCode)
 
 	wr, err := io.Copy(w, resp.Body)
 	if err != nil {


### PR DESCRIPTION
I just tried out cors-proxy, and it worked really well, except the response's headers didn't make it to my client. After inspection, is looks like I found the problem: Setting headers after `w.WriteHeader` can no longer affect the response.

To that effect, this PR changes the order of operations to set the response's headers first, then write the status code (and the headers) to the client.